### PR TITLE
Update README.md

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -2,8 +2,12 @@
 
 ### Setup
 
-- install `rustup`
-  - [link here](https://rustup.rs/)
+#### Install `rustup`
+- Run the following in your terminal, then follow the onscreen instructions.
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
 
 Note: You should be running >= version `1.72.1` of the rustc compiler, you can see that version with this command and
 should see similar output:


### PR DESCRIPTION
Added rustup installation directly in the README.md rather using an external link

### Description

- Added Rust installation instructions directly to the `README.md`, replacing the external link previously provided.

### Drive-by changes

- None

### Related issues

- None

### Backward compatibility

- Yes

### Testing

- Verified that the Rust installation instructions render correctly in Markdown.
- Followed the added installation steps to confirm successful `rustup` and Rust installation.
- Checked for any formatting issues or broken links in the README.
- Ensured the installation steps align with the official Rust installation method.
